### PR TITLE
Implement PostgreSQL-backed patent storage and pgvector retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ env/
 # Environment variables
 .env
 .env.local
+.env.*
 
 # IDE
 .vscode/

--- a/app.py
+++ b/app.py
@@ -1,20 +1,18 @@
 import io
-import os
 import zipfile
 
 import pandas as pd
 import requests
 import streamlit as st
 
+from db import get_patent_record, init_db, upsert_patent_record
 from functions import (
+    build_retrieval_payload,
     download_pdf,
     extract_text,
     get_pdf_link,
     normalize_url,
     patent_id_from_url,
-    patent_paths,
-    read_text_file,
-    save_text_file,
     summarize_text,
 )
 
@@ -104,6 +102,14 @@ def check_ollama():
         return False
 
 
+def check_database():
+    try:
+        init_db()
+        return True, ""
+    except Exception as exc:
+        return False, str(exc)
+
+
 def parse_urls_from_excel(file_obj):
     df = pd.read_excel(file_obj)
     if "url" not in df.columns:
@@ -117,41 +123,45 @@ def parse_urls_from_excel(file_obj):
 
 def process_patent_url(url, model_name, force_reprocess=False):
     patent_id = patent_id_from_url(url)
-    paths = patent_paths(patent_id)
+    existing = get_patent_record(patent_id)
 
     if (
         not force_reprocess
-        and os.path.exists(paths["pdf"])
-        and os.path.exists(paths["text"])
-        and os.path.exists(paths["summary"])
+        and existing
+        and existing.get("pdf_data")
+        and existing.get("text_content")
+        and existing.get("summary")
     ):
         return {
             "status": "cached",
             "url": url,
             "patent_id": patent_id,
-            "pdf_path": paths["pdf"],
-            "text_path": paths["text"],
-            "summary_path": paths["summary"],
-            "summary": read_text_file(paths["summary"]),
+            "summary": existing.get("summary", ""),
         }
 
     pdf_url = get_pdf_link(url)
-    download_pdf(pdf_url, paths["pdf"])
-    text = extract_text(paths["pdf"])
+    pdf_bytes = download_pdf(pdf_url)
+    text = extract_text(pdf_bytes=pdf_bytes)
     if not text.strip():
         raise ValueError("Extracted text is empty")
 
     summary = summarize_text(text, model=model_name)
-    save_text_file(paths["text"], text)
-    save_text_file(paths["summary"], summary)
+    chunks, embeddings = build_retrieval_payload(text)
+
+    upsert_patent_record(
+        patent_id=patent_id,
+        url=url,
+        pdf_data=pdf_bytes,
+        text_content=text,
+        summary=summary,
+        chunks=chunks,
+        embeddings=embeddings,
+    )
 
     return {
         "status": "done",
         "url": url,
         "patent_id": patent_id,
-        "pdf_path": paths["pdf"],
-        "text_path": paths["text"],
-        "summary_path": paths["summary"],
         "summary": summary,
     }
 
@@ -160,9 +170,14 @@ def create_pdf_zip(results):
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as archive:
         for item in results:
-            pdf_path = item.get("pdf_path")
-            if pdf_path and os.path.exists(pdf_path):
-                archive.write(pdf_path, arcname=f"{item['patent_id']}.pdf")
+            patent_id = item.get("patent_id")
+            if not patent_id:
+                continue
+
+            record = get_patent_record(patent_id)
+            pdf_bytes = record.get("pdf_data") if record else None
+            if pdf_bytes:
+                archive.writestr(f"{patent_id}.pdf", pdf_bytes)
     zip_buffer.seek(0)
     return zip_buffer
 
@@ -181,7 +196,10 @@ with st.container():
     st.markdown("</div>", unsafe_allow_html=True)
 
 if process_clicked and uploaded_file is not None:
-    if not check_ollama():
+    db_ok, db_error = check_database()
+    if not db_ok:
+        st.error(f"Database connection failed: {db_error}")
+    elif not check_ollama():
         st.error("Ollama is not reachable at localhost:11434. Start Ollama and retry.")
     else:
         try:

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from functions import (
     patent_id_from_url,
     summarize_text,
 )
+from db import has_patent_chunks, replace_patent_chunks
 
 st.set_page_config(layout="wide", page_title="Patent Studio")
 
@@ -124,6 +125,7 @@ def parse_urls_from_excel(file_obj):
 def process_patent_url(url, model_name, force_reprocess=False):
     patent_id = patent_id_from_url(url)
     existing = get_patent_record(patent_id)
+    has_chunks = has_patent_chunks(patent_id)
 
     if (
         not force_reprocess
@@ -131,6 +133,7 @@ def process_patent_url(url, model_name, force_reprocess=False):
         and existing.get("pdf_data")
         and existing.get("text_content")
         and existing.get("summary")
+        and has_chunks
     ):
         return {
             "status": "cached",
@@ -154,9 +157,8 @@ def process_patent_url(url, model_name, force_reprocess=False):
         pdf_data=pdf_bytes,
         text_content=text,
         summary=summary,
-        chunks=chunks,
-        embeddings=embeddings,
     )
+    replace_patent_chunks(patent_id, chunks, embeddings)
 
     return {
         "status": "done",

--- a/db.py
+++ b/db.py
@@ -4,10 +4,12 @@ from functools import lru_cache
 from pathlib import Path
 
 from dotenv import load_dotenv
-from sqlalchemy import JSON, DateTime, LargeBinary, String, Text, create_engine
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, LargeBinary, String, Text, create_engine, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
+VECTOR_DIM = int(os.getenv("PGVECTOR_DIM", "384"))
 
 
 class Base(DeclarativeBase):
@@ -26,6 +28,32 @@ class PatentRecord(Base):
     embeddings: Mapped[list | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class PatentChunk(Base):
+    __tablename__ = "patent_chunks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    patent_id: Mapped[str] = mapped_column(ForeignKey("patents.patent_id", ondelete="CASCADE"), nullable=False)
+    chunk_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    chunk_text: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding: Mapped[list[float]] = mapped_column(Vector(VECTOR_DIM), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+Index(
+    "ix_patent_chunks_patent_id",
+    PatentChunk.patent_id,
+)
+
+Index(
+    "ix_patent_chunks_embedding_ivfflat",
+    PatentChunk.embedding,
+    postgresql_using="ivfflat",
+    postgresql_with={"lists": 100},
+    postgresql_ops={"embedding": "vector_cosine_ops"},
+)
 
 
 def _now_utc():
@@ -53,7 +81,10 @@ def get_session_maker():
 
 
 def init_db():
-    Base.metadata.create_all(bind=get_engine())
+    engine = get_engine()
+    with engine.begin() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    Base.metadata.create_all(bind=engine)
 
 
 def _to_payload(record: PatentRecord | None):
@@ -78,6 +109,13 @@ def get_patent_record(patent_id):
     with Session() as session:
         record = session.get(PatentRecord, patent_id)
         return _to_payload(record)
+
+
+def has_patent_chunks(patent_id):
+    Session = get_session_maker()
+    with Session() as session:
+        count = session.query(PatentChunk).filter(PatentChunk.patent_id == patent_id).count()
+        return count > 0
 
 
 def upsert_patent_record(
@@ -119,3 +157,43 @@ def upsert_patent_record(
         session.commit()
         session.refresh(record)
         return _to_payload(record)
+
+
+def replace_patent_chunks(patent_id, chunks, embeddings):
+    if len(chunks) != len(embeddings):
+        raise ValueError("chunks and embeddings must have the same length")
+
+    Session = get_session_maker()
+    with Session() as session:
+        now = _now_utc()
+        session.query(PatentChunk).filter(PatentChunk.patent_id == patent_id).delete()
+
+        rows = []
+        for idx, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            rows.append(
+                PatentChunk(
+                    patent_id=patent_id,
+                    chunk_index=idx,
+                    chunk_text=chunk,
+                    embedding=embedding,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+        if rows:
+            session.bulk_save_objects(rows)
+        session.commit()
+
+
+def search_patent_chunks(patent_id, query_embedding, top_k=4):
+    Session = get_session_maker()
+    with Session() as session:
+        rows = (
+            session.query(PatentChunk.chunk_text)
+            .filter(PatentChunk.patent_id == patent_id)
+            .order_by(PatentChunk.embedding.cosine_distance(query_embedding))
+            .limit(top_k)
+            .all()
+        )
+        return [row[0] for row in rows]

--- a/db.py
+++ b/db.py
@@ -1,0 +1,121 @@
+import os
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import JSON, DateTime, LargeBinary, String, Text, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
+
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class PatentRecord(Base):
+    __tablename__ = "patents"
+
+    patent_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    url: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    pdf_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    text_content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    chunks: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    embeddings: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+def _now_utc():
+    return datetime.now(timezone.utc)
+
+
+def _get_database_url():
+    url = os.getenv("DATABASE_URL", "").strip()
+    if not url:
+        raise RuntimeError(
+            "DATABASE_URL is not set. Configure a PostgreSQL URL, for example: "
+            "postgresql+psycopg2://user:password@localhost:5432/patent_studio"
+        )
+    return url
+
+
+@lru_cache(maxsize=1)
+def get_engine():
+    return create_engine(_get_database_url(), pool_pre_ping=True, future=True)
+
+
+@lru_cache(maxsize=1)
+def get_session_maker():
+    return sessionmaker(bind=get_engine(), autoflush=False, autocommit=False, expire_on_commit=False)
+
+
+def init_db():
+    Base.metadata.create_all(bind=get_engine())
+
+
+def _to_payload(record: PatentRecord | None):
+    if record is None:
+        return None
+
+    return {
+        "patent_id": record.patent_id,
+        "url": record.url,
+        "pdf_data": record.pdf_data,
+        "text_content": record.text_content,
+        "summary": record.summary,
+        "chunks": record.chunks,
+        "embeddings": record.embeddings,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+    }
+
+
+def get_patent_record(patent_id):
+    Session = get_session_maker()
+    with Session() as session:
+        record = session.get(PatentRecord, patent_id)
+        return _to_payload(record)
+
+
+def upsert_patent_record(
+    patent_id,
+    url,
+    pdf_data=None,
+    text_content=None,
+    summary=None,
+    chunks=None,
+    embeddings=None,
+):
+    Session = get_session_maker()
+    with Session() as session:
+        record = session.get(PatentRecord, patent_id)
+        now = _now_utc()
+
+        if record is None:
+            record = PatentRecord(
+                patent_id=patent_id,
+                url=url,
+                created_at=now,
+                updated_at=now,
+            )
+
+        record.url = url
+        record.updated_at = now
+        if pdf_data is not None:
+            record.pdf_data = pdf_data
+        if text_content is not None:
+            record.text_content = text_content
+        if summary is not None:
+            record.summary = summary
+        if chunks is not None:
+            record.chunks = chunks
+        if embeddings is not None:
+            record.embeddings = embeddings
+
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+        return _to_payload(record)

--- a/diagrams/chat-rag-flow.mmd
+++ b/diagrams/chat-rag-flow.mmd
@@ -1,0 +1,37 @@
+sequenceDiagram
+    participant User
+    participant patent_viewer
+    participant functions.py
+    participant Storage
+    participant Ollama
+
+    User->>patent_viewer: Select patent + Go to Chat tab
+
+    User->>patent_viewer: Type question
+    patent_viewer->>functions.py: chat_with_patent(question, patent_text, ...)
+
+    functions.py->>functions.py: ensure_retrieval_index()
+    alt Index exists
+        Storage-->>functions.py: Load chunks.json + index.json
+    else Build new
+        functions.py->>functions.py: chunk_text
+        functions.py->>functions.py: _simple_embed each chunk
+        functions.py->>Storage: Save chunks.json + index.json
+    end
+
+    functions.py->>functions.py: _simple_embed(question)
+    functions.py->>functions.py: retrieve_chunks (cosine similarity)
+    functions.py->>functions.py: Get top 4 most relevant chunks
+
+    functions.py->>functions.py: Build message array:
+    functions.py->>functions.py: - system: answer from excerpts only
+    functions.py->>functions.py: - history: last 8 turns
+    functions.py->>functions.py: - user: question + context
+
+    functions.py->>Ollama: POST /api/chat with messages
+    Ollama-->>functions.py: LLM response (grounded, factual)
+
+    functions.py-->>patent_viewer: answer + relevant_chunks
+
+    patent_viewer->>User: Show answer
+    patent_viewer->>User: Expandable "Retrieved context" (4 chunks)

--- a/diagrams/patent-processing-flow.mmd
+++ b/diagrams/patent-processing-flow.mmd
@@ -1,0 +1,49 @@
+sequenceDiagram
+    participant User
+    participant app.py
+    participant functions.py
+    participant Selenium
+    participant Chrome
+    participant requests
+    participant Ollama
+    participant Storage
+
+    User->>app.py: Upload Excel + Click Process
+    app.py->>app.py: Parse Excel, get URLs
+
+    loop For each URL
+        app.py->>functions.py: process_patent_url(url)
+
+        alt Check Cache
+            functions.py->>Storage: Check if pdf/text/summary exist
+            Storage-->>functions.py: Found (cached=true)
+            functions.py-->>app.py: Return cached result
+        else Process New
+            functions.py->>functions.py: patent_id_from_url (SHA1 hash)
+            functions.py->>Selenium: get_pdf_link(url)
+
+            Selenium->>Chrome: Visit patent page
+            Chrome-->>Selenium: Page loaded
+            Selenium->>Chrome: Find PDF link XPath
+            Chrome-->>Selenium: URL found or click PDF button
+            Selenium-->>functions.py: Return PDF URL
+
+            functions.py->>requests: download_pdf(pdf_url)
+            requests-->>Storage: Save document.pdf
+
+            functions.py->>Storage: extract_text(pdf_path)
+            Storage-->>functions.py: Full patent text (10k-100k chars)
+
+            functions.py->>functions.py: chunk_text (1400 char chunks, 220 overlap)
+            functions.py->>functions.py: _simple_embed each chunk (sparse vectors)
+            functions.py->>Storage: Save chunks.json + index.json
+
+            functions.py->>Ollama: summarize_text (LLM call)
+            Ollama-->>functions.py: 1-paragraph summary
+            functions.py->>Storage: Save summary.txt
+
+            functions.py-->>app.py: Return result (done)
+        end
+    end
+
+    app.py->>User: Show results table + Download buttons

--- a/diagrams/system-architecture.mmd
+++ b/diagrams/system-architecture.mmd
@@ -1,0 +1,61 @@
+graph TB
+    subgraph UI["Frontend Layer (Streamlit)"]
+        A["app.py<br/>(Home/Upload)"]
+        B["patent_viewer.py<br/>(Patent Workspace)"]
+    end
+
+    subgraph Core["Core Processing Layer"]
+        C["functions.py<br/>(All Utilities)"]
+    end
+
+    subgraph Processing["Processing Pipeline"]
+        P1["PDF Link Extraction<br/>(Selenium)"]
+        P2["PDF Download<br/>(requests)"]
+        P3["Text Extraction<br/>(PyMuPDF)"]
+        P4["Summarization<br/>(Ollama LLM)"]
+        P5["Chunking & Embedding<br/>(Sparse tokens)"]
+    end
+
+    subgraph Retrieval["RAG System"]
+        R1["Chunk Storage<br/>(JSON)"]
+        R2["Embedding Index<br/>(JSON)"]
+        R3["Semantic Retrieval<br/>(Cosine similarity)"]
+        R4["Chat with Patent<br/>(Ollama)"]
+    end
+
+    subgraph Storage["Local Storage"]
+        S1["data/patents/{id}/<br/>document.pdf"]
+        S2["data/patents/{id}/<br/>document.txt"]
+        S3["data/patents/{id}/<br/>summary.txt"]
+        S4["data/patents/{id}/<br/>chunks.json"]
+        S5["data/patents/{id}/<br/>index.json"]
+    end
+
+    subgraph External["External Services"]
+        E1["Ollama<br/>localhost:11434"]
+    end
+
+    A -->|Excel Upload| A
+    A -->|Process Patents| P1
+    A -->|Results| B
+
+    P1 -->|Patent URL| P2
+    P2 -->|PDF Binary| P3
+    P3 -->|Full Text| P4
+    P4 -->|Summary| P5
+    P5 -->|Chunks & Embeddings| S1
+    S4 -->|Chunks| R1
+    S5 -->|Embeddings| R2
+
+    B -->|View Patent| B
+    B -->|Question| R3
+    R3 -->|Retrieved Chunks| R4
+    R4 -->|Answer| B
+
+    R4 -->|API Call| E1
+    P4 -->|API Call| E1
+
+    S1 --> S2
+    S2 --> S3
+    S3 --> S4
+    S4 --> S5

--- a/functions.py
+++ b/functions.py
@@ -1,17 +1,12 @@
 import hashlib
-import json
-import os
 import re
 import time
-from pathlib import Path
 
 import fitz  # PyMuPDF
 import requests
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
-
-DATA_ROOT = Path("data") / "patents"
 
 
 def normalize_url(url):
@@ -23,43 +18,25 @@ def patent_id_from_url(url):
     return f"pat_{digest}"
 
 
-def get_patent_dir(patent_id):
-    patent_dir = DATA_ROOT / patent_id
-    patent_dir.mkdir(parents=True, exist_ok=True)
-    return patent_dir
-
-
-def patent_paths(patent_id):
-    patent_dir = get_patent_dir(patent_id)
-    return {
-        "dir": str(patent_dir),
-        "pdf": str(patent_dir / "document.pdf"),
-        "text": str(patent_dir / "document.txt"),
-        "summary": str(patent_dir / "summary.txt"),
-        "chunks": str(patent_dir / "chunks.json"),
-        "index": str(patent_dir / "index.json"),
-        "meta": str(patent_dir / "metadata.json"),
-    }
-
-
-def save_text_file(path, content):
-    with open(path, "w", encoding="utf-8") as handle:
-        handle.write(content)
-
-
-def read_text_file(path):
-    with open(path, "r", encoding="utf-8") as handle:
-        return handle.read()
-
-
-def download_pdf(url, filename):
+def download_pdf(url, filename=None):
     response = requests.get(url, timeout=60)
     response.raise_for_status()
-    with open(filename, "wb") as handle:
-        handle.write(response.content)
+    pdf_bytes = response.content
+    if filename:
+        with open(filename, "wb") as handle:
+            handle.write(pdf_bytes)
+    return pdf_bytes
 
 
-def extract_text(pdf_path):
+def extract_text(pdf_path=None, pdf_bytes=None):
+    if pdf_bytes is not None:
+        with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+            pages = [page.get_text() for page in doc]
+        return "\n".join(pages).strip()
+
+    if not pdf_path:
+        raise ValueError("Either pdf_path or pdf_bytes must be provided")
+
     with fitz.open(pdf_path) as doc:
         pages = [page.get_text() for page in doc]
     return "\n".join(pages).strip()
@@ -102,24 +79,10 @@ def _cosine_sparse(a_vec, b_vec):
     return dot / (a_norm * b_norm)
 
 
-def build_retrieval_index(text, index_path, chunks_path):
+def build_retrieval_payload(text):
     chunks = chunk_text(text)
     embeddings = [_simple_embed(chunk) for chunk in chunks]
-    with open(chunks_path, "w", encoding="utf-8") as handle:
-        json.dump(chunks, handle, ensure_ascii=True, indent=2)
-    with open(index_path, "w", encoding="utf-8") as handle:
-        json.dump(embeddings, handle, ensure_ascii=True)
     return chunks, embeddings
-
-
-def ensure_retrieval_index(text, index_path, chunks_path):
-    if os.path.exists(index_path) and os.path.exists(chunks_path):
-        with open(chunks_path, "r", encoding="utf-8") as handle:
-            chunks = json.load(handle)
-        with open(index_path, "r", encoding="utf-8") as handle:
-            embeddings = json.load(handle)
-        return chunks, embeddings
-    return build_retrieval_index(text, index_path, chunks_path)
 
 
 def retrieve_chunks(question, chunks, embeddings, top_k=4):
@@ -181,9 +144,18 @@ This invention addresses discomfort and performance issues caused by the initial
     return chat_ollama(messages, model=model, temperature=0.1)
 
 
-def chat_with_patent(question, patent_text, index_path, chunks_path, history=None, model="llama3:8b"):
+def chat_with_patent(
+    question,
+    patent_text,
+    history=None,
+    model="llama3:8b",
+    chunks=None,
+    embeddings=None,
+):
     history = history or []
-    chunks, embeddings = ensure_retrieval_index(patent_text, index_path, chunks_path)
+    if chunks is None or embeddings is None:
+        chunks, embeddings = build_retrieval_payload(patent_text)
+
     relevant_chunks = retrieve_chunks(question, chunks, embeddings, top_k=4)
 
     context = "\n\n".join(
@@ -219,7 +191,7 @@ def chat_with_patent(question, patent_text, index_path, chunks_path, history=Non
         messages = [system_message] + history_messages + messages[1:]
 
     answer = chat_ollama(messages, model=model, temperature=0.0, top_p=0.85)
-    return answer, relevant_chunks
+    return answer, relevant_chunks, chunks, embeddings
 
 
 def get_pdf_link(url):

--- a/functions.py
+++ b/functions.py
@@ -1,12 +1,16 @@
 import hashlib
+import os
 import re
 import time
+from functools import lru_cache
 
 import fitz  # PyMuPDF
 import requests
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
+
+EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
 
 
 def normalize_url(url):
@@ -58,43 +62,36 @@ def chunk_text(text, chunk_size=1400, overlap=220):
     return chunks
 
 
-def _simple_embed(text):
-    tokens = re.findall(r"[a-z0-9]+", text.lower())
-    vec = {}
-    for token in tokens:
-        vec[token] = vec.get(token, 0.0) + 1.0
-    return vec
+@lru_cache(maxsize=1)
+def get_embedding_model():
+    # Lazy import avoids loading heavy transformer stacks during app startup.
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer(EMBEDDING_MODEL_NAME)
 
 
-def _cosine_sparse(a_vec, b_vec):
-    if not a_vec or not b_vec:
-        return 0.0
-    dot = 0.0
-    for token, a_val in a_vec.items():
-        dot += a_val * b_vec.get(token, 0.0)
-    a_norm = sum(v * v for v in a_vec.values()) ** 0.5
-    b_norm = sum(v * v for v in b_vec.values()) ** 0.5
-    if a_norm == 0.0 or b_norm == 0.0:
-        return 0.0
-    return dot / (a_norm * b_norm)
+def embed_texts_dense(texts):
+    if not texts:
+        return []
+
+    vectors = get_embedding_model().encode(
+        texts,
+        convert_to_numpy=True,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    )
+    return vectors.tolist()
+
+
+def embed_text_dense(text):
+    vectors = embed_texts_dense([text])
+    return vectors[0] if vectors else []
 
 
 def build_retrieval_payload(text):
     chunks = chunk_text(text)
-    embeddings = [_simple_embed(chunk) for chunk in chunks]
+    embeddings = embed_texts_dense(chunks)
     return chunks, embeddings
-
-
-def retrieve_chunks(question, chunks, embeddings, top_k=4):
-    query_vec = _simple_embed(question)
-    scored = []
-    for idx, emb in enumerate(embeddings):
-        scored.append((idx, _cosine_sparse(query_vec, emb)))
-    scored.sort(key=lambda pair: pair[1], reverse=True)
-    selected = [chunks[idx] for idx, score in scored[:top_k] if score > 0]
-    if not selected:
-        selected = chunks[: min(top_k, len(chunks))]
-    return selected
 
 
 def chat_ollama(messages, model="llama3:8b", temperature=0.1, top_p=0.9):
@@ -149,14 +146,14 @@ def chat_with_patent(
     patent_text,
     history=None,
     model="llama3:8b",
-    chunks=None,
-    embeddings=None,
+    retrieved_chunks=None,
 ):
     history = history or []
-    if chunks is None or embeddings is None:
-        chunks, embeddings = build_retrieval_payload(patent_text)
-
-    relevant_chunks = retrieve_chunks(question, chunks, embeddings, top_k=4)
+    if retrieved_chunks is None:
+        fallback_chunks = chunk_text(patent_text)
+        relevant_chunks = fallback_chunks[:4]
+    else:
+        relevant_chunks = retrieved_chunks
 
     context = "\n\n".join(
         [f"Excerpt {idx + 1}:\n{chunk}" for idx, chunk in enumerate(relevant_chunks)]
@@ -191,7 +188,7 @@ def chat_with_patent(
         messages = [system_message] + history_messages + messages[1:]
 
     answer = chat_ollama(messages, model=model, temperature=0.0, top_p=0.85)
-    return answer, relevant_chunks, chunks, embeddings
+    return answer, relevant_chunks
 
 
 def get_pdf_link(url):

--- a/pages/patent_viewer.py
+++ b/pages/patent_viewer.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
-from db import get_patent_record, init_db
-from functions import chat_with_patent
+from db import get_patent_record, init_db, search_patent_chunks
+from functions import chat_with_patent, embed_text_dense
 
 st.set_page_config(layout="wide", page_title="Patent Workspace", initial_sidebar_state="collapsed")
 
@@ -169,8 +169,6 @@ if not record:
 pdf_bytes = record.get("pdf_data")
 patent_text = record.get("text_content") or ""
 summary_text = selected.get("summary") or record.get("summary") or "No summary available."
-stored_chunks = record.get("chunks")
-stored_embeddings = record.get("embeddings")
 
 st.caption(selected["url"])
 
@@ -211,13 +209,19 @@ with tabs[2]:
 
             with st.chat_message("assistant"):
                 with st.spinner("Thinking over patent context..."):
-                    answer, chunks, _, _ = chat_with_patent(
+                    query_embedding = embed_text_dense(question)
+                    chunks = search_patent_chunks(
+                        patent_id=patent_id,
+                        query_embedding=query_embedding,
+                        top_k=4,
+                    )
+
+                    answer, chunks = chat_with_patent(
                         question=question,
                         patent_text=patent_text,
                         history=patent_history,
                         model=st.session_state["chat_model"],
-                        chunks=stored_chunks,
-                        embeddings=stored_embeddings,
+                        retrieved_chunks=chunks,
                     )
                     st.write(answer)
                     with st.expander("Retrieved context"):

--- a/pages/patent_viewer.py
+++ b/pages/patent_viewer.py
@@ -1,8 +1,7 @@
-import os
-
 import streamlit as st
 
-from functions import chat_with_patent, patent_paths, read_text_file
+from db import get_patent_record, init_db
+from functions import chat_with_patent
 
 st.set_page_config(layout="wide", page_title="Patent Workspace", initial_sidebar_state="collapsed")
 
@@ -24,6 +23,12 @@ st.markdown(
 results = st.session_state.get("results", [])
 if not results:
     st.switch_page("app.py")
+
+try:
+    init_db()
+except Exception as exc:
+    st.error(f"Database connection failed: {exc}")
+    st.stop()
 
 if "chat_histories" not in st.session_state:
     st.session_state["chat_histories"] = {}
@@ -155,24 +160,31 @@ st.session_state["selected_patent_index"] = selected_index
 
 selected = results[selected_index]
 patent_id = selected["patent_id"]
-pdf_path = os.path.abspath(selected["pdf_path"])
-text_path = selected["text_path"]
+record = get_patent_record(patent_id)
+
+if not record:
+    st.error("No patent record found in database.")
+    st.stop()
+
+pdf_bytes = record.get("pdf_data")
+patent_text = record.get("text_content") or ""
+summary_text = selected.get("summary") or record.get("summary") or "No summary available."
+stored_chunks = record.get("chunks")
+stored_embeddings = record.get("embeddings")
 
 st.caption(selected["url"])
 
 tabs = st.tabs(["PDF", "Summary", "Chat"])
 
 with tabs[0]:
-    if not os.path.exists(pdf_path):
-        st.error(f"PDF not found: {pdf_path}")
+    if not pdf_bytes:
+        st.error("PDF not found in database for this patent.")
     else:
-        with open(pdf_path, "rb") as handle:
-            pdf_bytes = handle.read()
         st.pdf(pdf_bytes)
 
 with tabs[1]:
     st.subheader("Summary")
-    st.markdown(selected.get("summary", "No summary available."))
+    st.markdown(summary_text)
 
 with tabs[2]:
     st.subheader("Chat With This Patent")
@@ -190,8 +202,8 @@ with tabs[2]:
 
     question = st.chat_input("Ask a question about this patent")
     if question:
-        if not os.path.exists(text_path):
-            st.error("No extracted text file found for this patent.")
+        if not patent_text.strip():
+            st.error("No extracted text found in database for this patent.")
         else:
             patent_history.append({"role": "user", "content": question})
             with st.chat_message("user"):
@@ -199,15 +211,13 @@ with tabs[2]:
 
             with st.chat_message("assistant"):
                 with st.spinner("Thinking over patent context..."):
-                    patent_text = read_text_file(text_path)
-                    paths = patent_paths(patent_id)
-                    answer, chunks = chat_with_patent(
+                    answer, chunks, _, _ = chat_with_patent(
                         question=question,
                         patent_text=patent_text,
-                        index_path=paths["index"],
-                        chunks_path=paths["chunks"],
                         history=patent_history,
                         model=st.session_state["chat_model"],
+                        chunks=stored_chunks,
+                        embeddings=stored_embeddings,
                     )
                     st.write(answer)
                     with st.expander("Retrieved context"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ requests
 pymupdf 
 openpyxl
 selenium
+sqlalchemy
+psycopg2-binary
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ selenium
 sqlalchemy
 psycopg2-binary
 python-dotenv
+pgvector
+sentence-transformers
+torchvision


### PR DESCRIPTION
## Summary
- Move patent persistence to PostgreSQL
- Add pgvector-backed chunk storage and nearest-neighbor retrieval
- Update ingestion and chat to use DB-backed artifacts
- Add env loading and required dependencies
- Include architecture diagrams for the new flow

## Related issues
- Closes #1 for the PostgreSQL migration work
- Follow-up AWS/S3 work tracked in #10

## Notes
- S3/object storage is intentionally deferred
- Existing records may still need a one-time backfill for chunk vectors
